### PR TITLE
Check for NULL.

### DIFF
--- a/windows/32/lib_mysqludf_sys/lib_mysqludf_sys/lib_mysqludf_sys.c
+++ b/windows/32/lib_mysqludf_sys/lib_mysqludf_sys/lib_mysqludf_sys.c
@@ -274,7 +274,8 @@ my_bool sys_get_init(
 ,	char *message
 ){
 	if(args->arg_count==1
-	&&	args->arg_type[0]==STRING_RESULT){
+	&&	args->arg_type[0]==STRING_RESULT
+	&&	args->args[0]!=NULL){
 		initid->maybe_null = 1;
 		return 0;
 	} else {

--- a/windows/64/lib_mysqludf_sys/lib_mysqludf_sys/lib_mysqludf_sys.c
+++ b/windows/64/lib_mysqludf_sys/lib_mysqludf_sys/lib_mysqludf_sys.c
@@ -274,7 +274,8 @@ my_bool sys_get_init(
 ,	char *message
 ){
 	if(args->arg_count==1
-	&&	args->arg_type[0]==STRING_RESULT){
+	&&	args->arg_type[0]==STRING_RESULT
+	&&	args->args[0]!=NULL){
 		initid->maybe_null = 1;
 		return 0;
 	} else {


### PR DESCRIPTION
Check for `NULL` before calling `getenv`.